### PR TITLE
build: target-files: Use prebuilt secure boot image

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1418,6 +1418,8 @@ $(BUILT_TARGET_FILES_PACKAGE): \
 	$(hide) $(ACP) $(INSTALLED_RECOVERYIMAGE_TARGET) $(zip_root)/BOOTABLE_IMAGES/
 ifdef INSTALLED_KERNEL_TARGET
 	$(hide) $(ACP) $(INSTALLED_KERNEL_TARGET) $(zip_root)/RECOVERY/kernel
+	$(hide) mkdir -p $(zip_root)/BOOTABLE_IMAGES
+	$(hide) $(ACP) $(PRODUCT_OUT)/recovery.img $(zip_root)/BOOTABLE_IMAGES/recovery.img
 endif
 ifdef INSTALLED_2NDBOOTLOADER_TARGET
 	$(hide) $(ACP) \
@@ -1447,6 +1449,7 @@ endif
 		$(TARGET_ROOT_OUT),$(zip_root)/BOOT/RAMDISK)
 ifdef INSTALLED_KERNEL_TARGET
 	$(hide) $(ACP) $(INSTALLED_KERNEL_TARGET) $(zip_root)/BOOT/kernel
+	$(hide) $(ACP) $(PRODUCT_OUT)/boot.img $(zip_root)/BOOTABLE_IMAGES/boot.img
 endif
 ifdef INSTALLED_2NDBOOTLOADER_TARGET
 	$(hide) $(ACP) \


### PR DESCRIPTION
Copy prebuilt secure boot.img when creating target-files. The
target-files are used to create an OTA update.

Change-Id: I6dc6f88e0935bb32b3328068d50750e171354d8f
